### PR TITLE
feat: Update the sign() example

### DIFF
--- a/api/sign.md
+++ b/api/sign.md
@@ -81,7 +81,7 @@ const signedTransaction = await window.arweaveWallet.sign(transaction);
 // TODO: post `signedTransaction` to the network or...
 
 // ...update the original transaction's fields with the signed transaction's
-// fields:
+// fields...
 
 transaction.setSignature({
   id: signedFields.id,
@@ -91,5 +91,5 @@ transaction.setSignature({
   signature: signedFields.signature
 });
 
-// TODO: and post `transaction` the transaction to the network
+// TODO: ...and post `transaction` to the network
 ```

--- a/api/sign.md
+++ b/api/sign.md
@@ -76,10 +76,13 @@ let transaction = await arweave.createTransaction({
 });
 
 // sign using arweave-js
-const signedFields = await window.arweaveWallet.sign(transaction);
+const signedTransaction = await window.arweaveWallet.sign(transaction);
 
-// update transaction fields with the
-// signed transaction's fields
+// TODO: post `signedTransaction` to the network or...
+
+// ...update the original transaction's fields with the signed transaction's
+// fields:
+
 transaction.setSignature({
   id: signedFields.id,
   owner: signedFields.owner,
@@ -88,5 +91,5 @@ transaction.setSignature({
   signature: signedFields.signature
 });
 
-// TODO: post the transaction to the network
+// TODO: and post `transaction` the transaction to the network
 ```


### PR DESCRIPTION
Update the sign() example to indicate the sign() function returns a signed transaction that can be directly posted to the network.